### PR TITLE
Fixed emailing of password issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,6 @@ RUN mkdir /app && mv $GOPATH/bin/goldapps /app/goldapps
 #    PRODUCTION STAGE    #
 ##########################
 FROM alpine
-MAINTAINER digIT <digit@chalmers.it>
-
-# Add standard certificates
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 # Set user
 RUN addgroup -S app

--- a/internal/pkg/services/gamma/service_test.go
+++ b/internal/pkg/services/gamma/service_test.go
@@ -111,7 +111,7 @@ func TestGetPostMails(t *testing.T) {
 		Active: true,
 		SuperGroup: FKITSuperGroup{
 			Type: "COMMITTEE",
-			Name: "supergroup",
+			Email: "supergroup@chalmers.it",
 		},
 		GroupMembers: []FKITUser{userA},
 	}
@@ -122,5 +122,5 @@ func TestGetPostMails(t *testing.T) {
 		{"kassorer@chalmers.it", "", []string{}, nil, false},
 		{"kassorer.kommitteer@chalmers.it", "", []string{}, nil, false}}
 
-	assert.Equal(t, want, getPostMails([]FKITGroup{groupA}))
+	assert.Equal(t, getPostMails([]FKITGroup{groupA}), want)
 }

--- a/internal/pkg/services/gamma/structs.go
+++ b/internal/pkg/services/gamma/structs.go
@@ -1,7 +1,6 @@
 package gamma
 
 import (
-	"fmt"
 	"github.com/cthit/goldapps/internal/pkg/model"
 )
 
@@ -82,16 +81,12 @@ type FKITGroup struct {
 }
 
 func (user *FKITUser) toUser(group *FKITGroup) model.User {
-	newUser := model.User{}
-	newUser.Cid = user.Cid
-	newUser.FirstName = user.FirstName
-	newUser.SecondName = user.LastName
-	newUser.Nick = user.Nick
-
-	if shouldHaveMail(group, user) {
-		newUser.Mail = fmt.Sprintf("%s@chalmers.it", user.Cid)
-	} else {
-		newUser.Mail = user.Email
+	newUser := model.User{
+		Cid: user.Cid,
+		FirstName: user.FirstName,
+		SecondName: user.LastName,
+		Nick: user.Nick,
+		Mail: user.Email,
 	}
 
 	return newUser


### PR DESCRIPTION
Currently when a new user is added, goldapps emails the password to the cid@chalmers.it email, but it should be emailing the user's personal email since the user does not have access to the cid@chalmers.it.