### PR TITLE
Fixed merge of groups not working correctly

### DIFF
--- a/internal/app/cli/additions.go
+++ b/internal/app/cli/additions.go
@@ -90,7 +90,7 @@ func mergeAdditionGroups(additionGroups model.Groups, providerGroups model.Group
 						}
 					}
 					if !memberFound {
-						providerGroups[i].Members = append(pgroup.Members, member)
+						providerGroups[i].Members = append(providerGroups[i].Members, member)
 					}
 				}
 			}


### PR DESCRIPTION
Currently, the merge of 
```
[{
    email: "aaa@chalmers.it",
    members: ["m1@chalmers.it"]
}]
```
from Gamma and
```
[{
    email: "aaa@chalmers.it",
    members: ["m2@chalmers.it", "m3@chalmers.it"]
}]
```
from `additions.json` results in
```
[{
    email: "aaa@chalmers.it",
    members: ["m1@chalmers.it", "m3@chalmers.it"]
}]
```
but it should be
```
[{
    email: "aaa@chalmers.it",
    members: ["m1@chalmers.it", "m2@chalmers.it", "m3@chalmers.it"]
}]
```
@cthit/digit Please accept!