### PR TITLE
Active groups are defined by not being part of an alumni group

### DIFF
--- a/internal/pkg/services/gamma/gammaRequests.go
+++ b/internal/pkg/services/gamma/gammaRequests.go
@@ -60,6 +60,14 @@ func getActiveGroups(s *GammaService) ([]FKITGroup, error) {
 	groups := struct {
 		GetFKITGroupResponse []FKITGroup `json:"groups"`
 	}{}
-	err := gammaReq(s, "/api/admin/groups/active", &groups)
-	return groups.GetFKITGroupResponse, err
+	err := gammaReq(s, "/api/admin/groups", &groups)
+	activeGroups := []FKITGroup{}
+	for i := range groups.GetFKITGroupResponse {
+		group := groups.GetFKITGroupResponse[i]
+		if group.SuperGroup.Type != "ALUMNI" {
+			activeGroups = append(activeGroups, group)
+		}
+	}
+
+	return activeGroups, err
 }

--- a/internal/pkg/services/gamma/service.go
+++ b/internal/pkg/services/gamma/service.go
@@ -23,7 +23,7 @@ func CreateGammaService(apiKey string, url string) (GammaService, error) {
 
 //Determins if the specified user in the specified group should have a gsuit account
 func shouldHaveMail(group *FKITGroup, member *FKITUser) bool {
-	return isFkit(group) && member.Gdpr && group.Active
+	return isFkit(group) && member.Gdpr
 }
 
 //Determins if specified group is a member of KIT


### PR DESCRIPTION
Makes it possible to give early access to google workspace for people without fiddling with mandate periods