### PR TITLE
Get additions file from config

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -10,6 +10,9 @@
     apiKey = "key"
     url = "http://localhost:8081"
 
+[additions]
+	file = "additions.json"
+
 [ldap]
 	url = "ldap.mydomain.ex:636"
 	servername = "mydomain.ex"

--- a/internal/app/web/services.go
+++ b/internal/app/web/services.go
@@ -111,7 +111,7 @@ func getChangeSuggestions(fromJson string, toJson string) (actions.UserActions, 
 	consumerUsers = collectUsers(consumer)
 
 	// Get and process additions
-	providerGroups, providerUsers = pkg.AddAdditions(providerGroups, providerUsers, "additions.json")
+	providerGroups, providerUsers = pkg.AddAdditions(providerGroups, providerUsers, viper.GetString("additions.file"))
 
 	// Check for and handle duplicates
 	providerUsers, providerGroups = duplicates.RemoveDuplicates(providerUsers, providerGroups)


### PR DESCRIPTION
With the move to digIT's new server we are using Docker Volumes instead of just bind mounting files and directories.
In the current version of goldapps we get the additions.json file from our working directory which makes it impossible to use docker volumes as they can only map folders and not individual files.

This PR reads the additions.json file path from the config.toml